### PR TITLE
Add fetching next page on scrolling to bottom

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,18 @@ Because of this, I reverted back to using the standard HTML img tag but it could
 I found through trial and error that https://picsum.photos/v2/list responds the same with page=0 and page=1. In other words, their index starts at 1.
 
 To determine the next page number, I'm taking the current number of pages and adding 1.
+
+### 2 pages loading when scrolling to bottom
+
+This bug occured when I reached to the bottom of the page and after successfully fetching the next page.
+The isFetchingContent boolean would then be reset to false by react-query and before the images had time to load, another fetch was being made.
+
+Setting a minimum height on the grid rows meant that as soon as React re-rendered with the new content, the user would no longer be at the bottom of the page.
+
+### radash throttle vs lodash throttle
+
+I started by using radash's throttle function but ran into an issue with handleScroll invocations being too early in the scroll and not recalling when the user finished the scrolling to the bottom of the page.
+
+By looking at [radash's documentation on the throttle timing](https://radash-docs.vercel.app/docs/curry/throttle#timing), I found this was by design.
+
+[Lodash's throttle](https://radash-docs.vercel.app/docs/curry/throttle#timing) has leading and trailing options and with the default trailing=true, I was getting that final handleScroll at the end of the user's scroll.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/react-query": "^4.33.0",
+        "lodash": "^4.17.21",
         "next": "13.4.19",
         "react": "18.2.0",
         "react-dom": "18.2.0"
       },
       "devDependencies": {
+        "@types/lodash": "^4.14.197",
         "@types/node": "20.5.6",
         "@types/react": "18.2.21",
         "@types/react-dom": "18.2.7",
@@ -432,6 +434,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.197",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.197.tgz",
+      "integrity": "sha512-BMVOiWs0uNxHVlHBgzTIqJYmj+PgCo4euloGF+5m4okL3rEYzM2EEv78mw8zWSMM57dM7kVIgJ2QDvwHSoCI5g==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -2770,6 +2778,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^4.33.0",
+    "lodash": "^4.17.21",
     "next": "13.4.19",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.197",
     "@types/node": "20.5.6",
     "@types/react": "18.2.21",
     "@types/react-dom": "18.2.7",

--- a/src/components/ContentGrid/ContentGrid.tsx
+++ b/src/components/ContentGrid/ContentGrid.tsx
@@ -1,14 +1,19 @@
 "use client";
-
 import { ContentItem } from "./ContentItem";
 import { useContentItemsQuery } from "./useContentItemsQuery";
+import { useReachBottomListener } from "./useReachBottomListener";
 
 export function ContentGrid() {
-  const { allContentItems, fetchNextPage } = useContentItemsQuery();
+  const { allContentItems, fetchNextPage, isFetchingContent } =
+    useContentItemsQuery();
 
-  function handleNextPageClick() {
-    fetchNextPage();
+  function handleReachBottom() {
+    if (!isFetchingContent) {
+      fetchNextPage();
+    }
   }
+
+  useReachBottomListener({ onReachBottom: handleReachBottom });
 
   return (
     <>
@@ -17,9 +22,6 @@ export function ContentGrid() {
           <ContentItem key={contentItem.id} {...contentItem} />
         ))}
       </ul>
-      <button onClick={handleNextPageClick} type="button">
-        Next page
-      </button>
     </>
   );
 }

--- a/src/components/ContentGrid/ContentGrid.tsx
+++ b/src/components/ContentGrid/ContentGrid.tsx
@@ -17,7 +17,7 @@ export function ContentGrid() {
 
   return (
     <>
-      <ul className="grid grid-cols-3 gap-8">
+      <ul className="auto-rows-min-75 gap-8 grid grid-cols-3">
         {allContentItems.map((contentItem) => (
           <ContentItem key={contentItem.id} {...contentItem} />
         ))}

--- a/src/components/ContentGrid/useContentItemsQuery.ts
+++ b/src/components/ContentGrid/useContentItemsQuery.ts
@@ -3,17 +3,18 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 const PAGE_SIZE = 12;
 
 export function useContentItemsQuery(): UseContentItemsQueryReturn {
-  const { data, fetchNextPage } = useInfiniteQuery({
+  const { data, fetchNextPage, isFetching } = useInfiniteQuery({
     queryKey: ["content"],
     queryFn: getPicsumPhotos,
     getNextPageParam: (_, pages) => pages.length + 1,
   });
 
-  const allPhotoItems = data?.pages.flatMap((page) => page) ?? [];
+  const allPhotoItems = data?.pages.flatMap((page) => page ?? []) ?? [];
   const allContentItems = allPhotoItems?.map(transformContentItem);
 
   return {
     allContentItems,
+    isFetchingContent: isFetching,
     fetchNextPage,
   };
 }
@@ -21,6 +22,7 @@ export function useContentItemsQuery(): UseContentItemsQueryReturn {
 interface UseContentItemsQueryReturn {
   allContentItems: ContentItemModel[];
   fetchNextPage: () => void;
+  isFetchingContent: boolean;
 }
 
 function getPicsumPhotos({ pageParam = 1 }): Promise<PicsumPhotosResponseBody> {

--- a/src/components/ContentGrid/useReachBottomListener.ts
+++ b/src/components/ContentGrid/useReachBottomListener.ts
@@ -1,0 +1,40 @@
+import throttle from "lodash/throttle";
+import { useMemo, useEffect } from "react";
+
+const BOTTOM_OFFSET = 100;
+
+export function useReachBottomListener({
+  onReachBottom,
+}: UseReachBottomListenerProps) {
+  const handleScroll = useMemo(
+    () =>
+      throttle(() => {
+        const distanceFromBottom = calculateDistanceFromBottom();
+
+        if (distanceFromBottom < BOTTOM_OFFSET) {
+          onReachBottom();
+        }
+      }, 100),
+    [onReachBottom]
+  );
+
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [handleScroll]);
+}
+
+interface UseReachBottomListenerProps {
+  onReachBottom: () => void;
+}
+
+/**
+ * Calculates the distance between the bottom of the window and the bottom of the page
+ */
+function calculateDistanceFromBottom(): number {
+  const windowBottomPosition = window.scrollY + window.innerHeight;
+  return document.documentElement.scrollHeight - windowBottomPosition;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,6 +11,9 @@ const config: Config = {
       colors: {
         red: "#FF0000",
       },
+      gridAutoRows: {
+        "min-75": "minmax(300px, auto)",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
Added
- useReachBottomListener to trigger reachBottom events
- lodash for throttle function
- isFetchingContent return property in useContentItemsQuery
- Notes on double fetching issue
- Notes on throttle issue

Removed
- "Next page" button